### PR TITLE
feat: Add overloads for createStore function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-state",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A state management library for React",
   "main": "build/index.js",
   "module": "build/index.es.js",

--- a/src/components/__tests__/AtomContext.spec.tsx
+++ b/src/components/__tests__/AtomContext.spec.tsx
@@ -2,7 +2,7 @@ import React, { useContext, FunctionComponent } from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import AtomContext, { DefaultAtomStore } from '../AtomContext'
-import { createStore } from '../../core/AtomStore'
+import createStore from '../../utils/createStore'
 
 const consoleError = console.error.bind(console)
 

--- a/src/components/__tests__/AtomRoot.spec.tsx
+++ b/src/components/__tests__/AtomRoot.spec.tsx
@@ -2,7 +2,7 @@ import React, { useContext, FunctionComponent } from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import AtomContext from '../AtomContext'
-import { createStore } from '../../core/AtomStore'
+import createStore from '../../utils/createStore'
 import AtomRoot from '../AtomRoot'
 
 const consoleError = console.error.bind(console)

--- a/src/core/AtomStore.ts
+++ b/src/core/AtomStore.ts
@@ -9,10 +9,6 @@ export interface IAtomStore {
   unsubscribeAtom: (key: any, listener: AtomStoreListener) => void
 }
 
-export function createStore (defaultAtoms?: Map<any, any>): AtomStore {
-  return new AtomStore(defaultAtoms)
-}
-
 export default class AtomStore implements IAtomStore {
   subscriptionsForAtoms: Map<any, Array<AtomStoreListener>>
   batcher: Batcher

--- a/src/core/__tests__/AtomStore.spec.ts
+++ b/src/core/__tests__/AtomStore.spec.ts
@@ -1,4 +1,5 @@
-import AtomStore, { createStore } from '../AtomStore'
+import AtomStore from '../AtomStore'
+import createStore from '../../utils/createStore'
 
 test('AtomStore can be initialized with empty param', () => {
   let store = new AtomStore()

--- a/src/hooks/__tests__/useAtomState.spec.tsx
+++ b/src/hooks/__tests__/useAtomState.spec.tsx
@@ -4,7 +4,7 @@ import { render, fireEvent, screen } from '@testing-library/react'
 import { renderHook, act } from '@testing-library/react-hooks'
 
 import AtomRoot from '../../components/AtomRoot'
-import { createStore } from '../../core/AtomStore'
+import createStore from '../../utils/createStore'
 import useAtomState from '../useAtomState'
 
 test('useAtomState should return the atom state', () => {

--- a/src/hooks/__tests__/useStore.spec.tsx
+++ b/src/hooks/__tests__/useStore.spec.tsx
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import { DefaultAtomStore } from '../../components/AtomContext'
 import AtomRoot from '../../components/AtomRoot'
-import { createStore } from '../../core/AtomStore'
+import createStore from '../../utils/createStore'
 import useStore from '../useStore'
 
 test('useStore should return a default store if there is no AtomContext', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,12 @@ import AtomRoot from './components/AtomRoot'
 import AtomContext from './components/AtomContext'
 import AtomStore, {
   IAtomStore,
-  AtomStoreListener,
-  createStore
+  AtomStoreListener
 } from './core/AtomStore'
 import useStore from './hooks/useStore'
 import useAtomState from './hooks/useAtomState'
+
+import createStore from './utils/createStore'
 
 export {
   createStore,

--- a/src/utils/__tests__/createStore.spec.ts
+++ b/src/utils/__tests__/createStore.spec.ts
@@ -1,0 +1,60 @@
+import createStore from '../createStore';
+import AtomStore from '../../core/AtomStore';
+
+test('create store with empty parms', () => {
+  let store = createStore();
+  expect(store instanceof AtomStore).toBe(true);
+  expect(store.atomValues.size).toBe(0);
+});
+
+test('create store with a Map', () => {
+  let atoms = new Map([['foo', 'bar'], ["name", 'atom-state']]);
+  let store = createStore(atoms);
+  expect(store instanceof AtomStore).toBe(true);
+  expect(store instanceof AtomStore).toBe(true);
+  expect(store.atomValues.size).toBe(2);
+});
+
+test('create store with an object parms', () => {
+  let store = createStore({
+    'foo': 'bar',
+    'name': 'atom-state',
+  });
+  expect(store instanceof AtomStore).toBe(true);
+  expect(store instanceof AtomStore).toBe(true);
+  expect(store.atomValues.size).toBe(2);
+});
+
+test('create store with an DefaultAtomType', () => {
+  let store = createStore([
+    {
+      key: 'foo',
+      default: 'bar'
+    },
+    {
+      key: 'name',
+      default: 'atom-state'
+    },
+    {
+      key: '1',
+      default: '1',
+    },
+    {
+      key: 1, // should be a different key with '1'
+      default: 1,
+    },
+    {
+      key: Symbol('name'),
+      default: 'atom-state symbol',
+    }
+  ]);
+  expect(store instanceof AtomStore).toBe(true);
+  expect(store.atomValues.size).toBe(5);
+});
+
+test('create store with an array', () => {
+  let store = createStore([['foo', 'bar'], ["name", 'atom-state']]);
+  expect(store instanceof AtomStore).toBe(true);
+  expect(store instanceof AtomStore).toBe(true);
+  expect(store.atomValues.size).toBe(2);
+});

--- a/src/utils/createStore.ts
+++ b/src/utils/createStore.ts
@@ -1,0 +1,36 @@
+import AtomStore from '../core/AtomStore';
+
+export type DefaultAtomType = {
+  key: any,
+  default: any,
+}
+
+export default function createStore (): AtomStore;
+export default function createStore (defaultAtoms: Map<any, any>): AtomStore;
+export default function createStore (defaultAtoms: Array<DefaultAtomType>): AtomStore;
+export default function createStore (defaultAtoms: Object): AtomStore;
+
+export default function createStore (defaultAtoms?: Map<any, any> | Array<DefaultAtomType> | Object): AtomStore {
+  let atoms: any;
+  if (defaultAtoms instanceof Map) {
+    atoms = defaultAtoms;
+  } else if (Array.isArray(defaultAtoms) && defaultAtoms.length && defaultAtoms[0].key) {
+    // Array with DefaultAtomType 
+    atoms = defaultAtoms.reduce((acc, atom) => {
+      if (atom && atom.key && atom.default) {
+        acc.set(atom.key, atom.default);
+      }
+      return acc;
+    }, new Map());
+  } else if (typeof defaultAtoms === 'object') {
+    // Convert a normal object to Map
+    atoms = Object.keys(defaultAtoms).reduce((acc, key) => {
+      acc.set(key, defaultAtoms[key]);
+      return acc;
+    }, new Map());
+  } else {
+    atoms = new Map(defaultAtoms);
+  }
+
+  return new AtomStore(atoms)
+}


### PR DESCRIPTION
createStore can accept these types:
- undefined
- Object
- Map
- Array with defaultAtom type which every item has key and default property